### PR TITLE
Handle empty ASN lookups

### DIFF
--- a/fastd-exporter.go
+++ b/fastd-exporter.go
@@ -237,15 +237,18 @@ func (exporter PrometheusExporter) Collect(channel chan<- prometheus.Metric) {
 				ipAddrFamily = 4
 			}
 
+			peerAsn := float64(0)
 			asnlookup, err := ipisp.LookupIP(context.Background(), net.ParseIP(peerIp))
 			if err != nil {
 				log.Print(err)
+			} else {
+				peerAsn = float64(asnlookup.ASN)
 			}
 
 			channel <- prometheus.MustNewConstMetric(exporter.peerUp, prometheus.GaugeValue, float64(1), publicKey, peerName, interfaceName, method)
 			channel <- prometheus.MustNewConstMetric(exporter.peerUptime, prometheus.GaugeValue, peer.Connection.Established/1000, publicKey, peerName, interfaceName, method)
 			channel <- prometheus.MustNewConstMetric(exporter.peerIpAddrFamily, prometheus.GaugeValue, float64(ipAddrFamily), publicKey, peerName, interfaceName, method)
-			channel <- prometheus.MustNewConstMetric(exporter.peerAsn, prometheus.GaugeValue, float64(asnlookup.ASN), publicKey, peerName, interfaceName, method)
+			channel <- prometheus.MustNewConstMetric(exporter.peerAsn, prometheus.GaugeValue, peerAsn, publicKey, peerName, interfaceName, method)
 
 			channel <- prometheus.MustNewConstMetric(exporter.peerRxPackets, prometheus.CounterValue, float64(peer.Connection.Statistics.Rx.Count), publicKey, peerName, interfaceName, method)
 			channel <- prometheus.MustNewConstMetric(exporter.peerRxBytes, prometheus.CounterValue, float64(peer.Connection.Statistics.Rx.Bytes), publicKey, peerName, interfaceName, method)


### PR DESCRIPTION
ipisp.LookupIP() returns a nil value when the lookup fails. This commit sets the peerAsn to 0 if the ASN could not be resloved.

For example in one of our domains there seems to be a node connecting through the client network of an other node and therefore the fastd peer has a private IP which can't be resolved via origin.asn.cymru.com.

```
2022/04/14 12:27:28 lookup 224.20.86.10.origin.asn.cymru.com on 127.0.0.1:53: no such host
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x82865d]

goroutine 26 [running]:
main.PrometheusExporter.Collect(0xc0000c8060, 0x22, 0xc00009afc0, 0xc00009b030, 0xc00009b0a0, 0xc00009b110, 0xc00009b180, 0xc00009b1f0, 0xc00009b260, 0xc00009b2d0, ...)
	/git/fastd-exporter/fastd-exporter.go:250 +0xf7d
github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
	/go/pkg/mod/github.com/prometheus/client_golang@v1.12.1/prometheus/registry.go:446 +0x1a2
created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather
	/go/pkg/mod/github.com/prometheus/client_golang@v1.12.1/prometheus/registry.go:538 +0xe8e
```